### PR TITLE
style: gratitude board cards

### DIFF
--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -988,8 +988,6 @@ main.login-content {
 
 .gratitude-board-card, .gratitude-card {
     background: rgba( 255, 255, 255, 0.90 ) !important;
-    backdrop-filter: blur( 20.0px ) !important;
-    -webkit-backdrop-filter: blur( 20.0px ) !important;
     border-radius: 20px !important;
     border: 1px solid rgba( 255, 255, 255, 0.18 ) !important;
     box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2) !important;


### PR DESCRIPTION
Hi, team! 

I reviewed the gratitude board and noticed there was a white backdrop filter around the gratitude board cards. I removed this filter, that way the cards are consistent with the UI across the application. Let me know if you have any questions. 😊

-Elvira